### PR TITLE
LogResponseData extension,  onSuccessData and onResult callbacks

### DIFF
--- a/CodyFire/Classes/APIRequest+Build.swift
+++ b/CodyFire/Classes/APIRequest+Build.swift
@@ -145,6 +145,13 @@ extension APIRequest {
     }
     
     @discardableResult
+    public func onSuccessData(_ callback: @escaping DataResponse) -> APIRequest {
+        dataCallback = callback
+        start()
+        return self
+    }
+    
+    @discardableResult
     @available(*, deprecated, renamed: "onError")
     public func onKnownError(_ callback: @escaping ErrorResponse) -> APIRequest {
         errorCallback = callback

--- a/CodyFire/Classes/APIRequest+LogResponse.swift
+++ b/CodyFire/Classes/APIRequest+LogResponse.swift
@@ -1,0 +1,19 @@
+//
+//  ApiRequest+LogResponse.swift
+//  BuhurtApp
+//
+//  Created by Максим Кудрявцев on 08/04/2019.
+//  Copyright © 2019 Horoko. All rights reserved.
+//
+
+import CodyFire
+
+extension APIRequest {
+    func logResponseData() -> APIRequest {
+        onSuccessData { data in
+            let message = "Response body: \(String(bytes: data, encoding: .nonLossyASCII) ?? "Can`t parse body")"
+            log(.debug, message)
+        }
+        return self
+    }
+}

--- a/CodyFire/Classes/APIRequest+ParseResponse.swift
+++ b/CodyFire/Classes/APIRequest+ParseResponse.swift
@@ -24,6 +24,7 @@ extension APIRequest {
                     ?? DateCodingStrategy.default.jsonDateDecodingStrategy
                 var errorRaised = false
                 if let data = answer.data {
+                    self.dataCallback?(data)
                     if ResultType.self is Nothing.Type {
                         delayedResponse(diff) {
                             CodyFire.shared.successResponseHandler?(self.host, self.endpoint)

--- a/CodyFire/Classes/APIRequest+Result.swift
+++ b/CodyFire/Classes/APIRequest+Result.swift
@@ -1,0 +1,20 @@
+//
+//  ApiRequest + Result.swift
+//  BuhurtApp
+//
+//  Created by Максим Кудрявцев on 08/04/2019.
+//  Copyright © 2019 Horoko. All rights reserved.
+//
+
+import CodyFire
+
+extension APIRequest {
+    func onResult(_ handler: @escaping (Result<ResultType, NetworkError>) -> Void) -> APIRequest {
+        onError { error in
+            handler(.failure(error))
+        }.onSuccess { result in
+            handler(.success(result))
+        }
+        return self
+    }
+}

--- a/CodyFire/Classes/APIRequest.swift
+++ b/CodyFire/Classes/APIRequest.swift
@@ -35,6 +35,7 @@ public class APIRequest<ResultType: Decodable> {
     let uid = UUID()
     
     public typealias SuccessResponse = (ResultType)->()
+    public typealias DataResponse = (Data)->()
     var customServerURL: ServerURL?
     var customErrors: [NetworkError] = []
     var endpoint: String = "/"
@@ -44,6 +45,7 @@ public class APIRequest<ResultType: Decodable> {
     var headers: [String: String] = CodyFire.shared.globalHeaders
     var desiredStatusCode: StatusCode = .ok
     var successCallback: SuccessResponse?
+    var dataCallback: DataResponse?
     var errorCallback: ErrorResponse?
     var notAuthorizedCallback: NotAuthorizedResponse?
     var progressCallback: Progress?


### PR DESCRIPTION
Added extension for logging response data. As well as a callback onResult for Result<>.